### PR TITLE
Dev unasl crit tool fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ criu/include/version.h
 criu/pie/restorer-blob.h
 criu/pie/parasite-blob.h
 criu/protobuf-desc-gen.h
+build/
 lib/build/
 lib/c/criu.pc
 scripts/build/qemu-user-static/*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,6 +49,17 @@ If a package was installed after a failed compilation, use "make mrproper-top" t
 
 Additional packages maybe needed, please refer to: https://criu.org/Installation
 
+In order to allow multiple installations to work in conjunction with one another (i.e., no conflicts or shadow imports)
+the optional environment variable `PY_PKG_DIR` can be set denoting the name of top-level Python module to be used.
+`PY_PKG_DIR` defaults to "pycriu" (i.e., `import pycriu`), if not set explicitly at the commandline.
+If the installation directory is non-standard (i.e., not within `python -m site` locations), you might have to export or
+adjust the `PYTHONPATH` environment variable too, i.e.:
+
+```
+make install PY_PKG_DIR=pycriu_alt DESTDIR=/usr/local/criu-het-unasl PREFIX= PYTHON=python3
+export PYTHONPATH=/usr/local/criu-het-unasl/lib/python3.9/site-packages/
+```
+
 Moreover, it might be preferable to actually select which Python version (2 or 3) the installed Python tools (e.g.,
 `crit`) are meant to use.
 This can be forced by selected the corresponding Python interpreter during building and installing by setting the

--- a/Makefile.config
+++ b/Makefile.config
@@ -15,6 +15,7 @@ endif
 export LIBS += $(LIBS_FEATURES)
 
 CONFIG_FILE = .config
+PY_PKG_DIR ?= pycriu
 
 $(CONFIG_FILE):
 	touch $(CONFIG_FILE)

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -2,7 +2,7 @@
 all-y	+= crit
 
 crit/crit: crit/crit-$(PYTHON)
-	$(Q) cp $^ $@
+	$(Q) sed -e 's,@py_pkg_dir@,$(PY_PKG_DIR),' $^ > $@
 crit: crit/crit
 .PHONY: crit
 

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -1,8 +1,8 @@
 
 all-y	+= crit
 
-crit/crit: crit/crit-$(PYTHON)
-	$(Q) PY_PKG_DIR=$(PY_PKG_DIR) sed -e 's,@py_pkg_dir@,$(PY_PKG_DIR),' $^ > $@
+crit/crit: crit/crit-$(PYTHON) .FORCE
+	$(Q) PY_PKG_DIR=$(PY_PKG_DIR) sed -e 's,@py_pkg_dir@,$(PY_PKG_DIR),' $< > $@
 crit: crit/crit
 .PHONY: crit
 
@@ -11,3 +11,5 @@ clean-crit:
 .PHONY: clean-crit
 clean: clean-crit
 mrproper: clean
+
+.FORCE: ;

--- a/crit/Makefile
+++ b/crit/Makefile
@@ -2,7 +2,7 @@
 all-y	+= crit
 
 crit/crit: crit/crit-$(PYTHON)
-	$(Q) sed -e 's,@py_pkg_dir@,$(PY_PKG_DIR),' $^ > $@
+	$(Q) PY_PKG_DIR=$(PY_PKG_DIR) sed -e 's,@py_pkg_dir@,$(PY_PKG_DIR),' $^ > $@
 crit: crit/crit
 .PHONY: crit
 

--- a/crit/crit-python2
+++ b/crit/crit-python2
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-from pycriu import cli
+from @py_pkg_dir@ import cli
 
 if __name__ == '__main__':
 	cli.main()

--- a/crit/crit-python3
+++ b/crit/crit-python3
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pycriu import cli
+from @py_pkg_dir@ import cli
 
 if __name__ == '__main__':
 	cli.main()

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -53,7 +53,7 @@ install: lib-c lib-py crit/crit lib/c/criu.pc.in
 	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
 	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig
 	$(E) "  INSTALL " crit
-	$(Q) $(PYTHON) scripts/crit-setup.py install --prefix=$(DESTDIR)$(PREFIX) --record $(CRIT_SETUP_FILES)
+	$(Q) PY_PKG_DIR=$(PY_PKG_DIR) $(PYTHON) scripts/crit-setup.py install --prefix=$(DESTDIR)$(PREFIX) --record $(CRIT_SETUP_FILES)
 .PHONY: install
 
 uninstall:

--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -5,8 +5,8 @@ import json
 import os
 from shutil import copyfile
 
-import pycriu
-from pycriu.het import Aarch64Converter, X8664Converter
+from . import images as pycriu_images
+from .het import Aarch64Converter, X8664Converter
 
 def inf(opts):
 	if opts['in']:
@@ -27,8 +27,8 @@ def decode(opts):
 	indent = None
 
 	try:
-		img = pycriu.images.load(inf(opts), opts['pretty'], opts['nopl'])
-	except pycriu.images.MagicException as exc:
+		img = pycriu_images.load(inf(opts), opts['pretty'], opts['nopl'])
+	except pycriu_images.MagicException as exc:
 		print("Unknown magic %#x.\n"\
 				"Maybe you are feeding me an image with "\
 				"raw data(i.e. pages.img)?" % exc.magic, file=sys.stderr)
@@ -60,10 +60,10 @@ def recode(opts):
 
 def encode(opts):
 	img = json.load(inf(opts))
-	pycriu.images.dump(img, outf(opts))
+	pycriu_images.dump(img, outf(opts))
 
 def info(opts):
-	infs = pycriu.images.info(inf(opts))
+	infs = pycriu_images.info(inf(opts))
 	json.dump(infs, sys.stdout, indent = 4)
 	print()
 
@@ -89,9 +89,9 @@ def show_ps(p, opts, depth = 0):
 
 def explore_ps(opts):
 	pss = { }
-	ps_img = pycriu.images.load(dinf(opts, 'pstree.img'))
+	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
 	for p in ps_img['entries']:
-		core = pycriu.images.load(dinf(opts, 'core-%d.img' % get_task_id(p, 'pid')))
+		core = pycriu_images.load(dinf(opts, 'core-%d.img' % get_task_id(p, 'pid')))
 		ps = ps_item(p, core['entries'][0])
 		pss[ps.pid] = ps
 
@@ -180,18 +180,18 @@ def get_file_str(opts, fd):
 	return f
 
 def explore_fds(opts):
-	ps_img = pycriu.images.load(dinf(opts, 'pstree.img'))
+	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
 	for p in ps_img['entries']:
 		pid = get_task_id(p, 'pid')
-		idi = pycriu.images.load(dinf(opts, 'ids-%s.img' % pid))
+		idi = pycriu_images.load(dinf(opts, 'ids-%s.img' % pid))
 		fdt = idi['entries'][0]['files_id']
-		fdi = pycriu.images.load(dinf(opts, 'fdinfo-%d.img' % fdt))
+		fdi = pycriu_images.load(dinf(opts, 'fdinfo-%d.img' % fdt))
 
 		print("%d" % pid)
 		for fd in fdi['entries']:
 			print("\t%7d: %s" % (fd['fd'], get_file_str(opts, fd)))
 
-		fdi = pycriu.images.load(dinf(opts, 'fs-%d.img' % pid))['entries'][0]
+		fdi = pycriu_images.load(dinf(opts, 'fs-%d.img' % pid))['entries'][0]
 		print("\t%7s: %s" % ('cwd', get_file_str(opts, {'type': 'REG', 'id': fdi['cwd_id']})))
 		print("\t%7s: %s" % ('root', get_file_str(opts, {'type': 'REG', 'id': fdi['root_id']})))
 
@@ -211,11 +211,11 @@ class vma_id:
 		return ret
 
 def explore_mems(opts):
-	ps_img = pycriu.images.load(dinf(opts, 'pstree.img'))
+	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
 	vids = vma_id()
 	for p in ps_img['entries']:
 		pid = get_task_id(p, 'pid')
-		mmi = pycriu.images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]
+		mmi = pycriu_images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]
 
 		print("%d" % pid)
 		print("\t%-36s    %s" % ('exe', get_file_str(opts, {'type': 'REG', 'id': mmi['exe_file_id']})))
@@ -257,11 +257,11 @@ def explore_mems(opts):
 
 
 def explore_rss(opts):
-	ps_img = pycriu.images.load(dinf(opts, 'pstree.img'))
+	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
 	for p in ps_img['entries']:
 		pid = get_task_id(p, 'pid')
-		vmas = pycriu.images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]['vmas']
-		pms = pycriu.images.load(dinf(opts, 'pagemap-%d.img' % pid))['entries']
+		vmas = pycriu_images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]['vmas']
+		pms = pycriu_images.load(dinf(opts, 'pagemap-%d.img' % pid))['entries']
 
 		print("%d" % pid)
 		vmi = 0

--- a/lib/py/criu.py
+++ b/lib/py/criu.py
@@ -6,7 +6,7 @@ import fcntl
 import os
 import struct
 
-import pycriu.rpc_pb2 as rpc
+from . import rpc_pb2 as rpc
 
 class _criu_comm:
 	"""

--- a/lib/py/het.py
+++ b/lib/py/het.py
@@ -70,8 +70,9 @@ class Converter():
 	### Common
 	def get_symbol_addr(self, binary, symbol):
 		if len(binary_symbols) == 0:
-			session = subprocess.Popen(['nm', binary], stdout=PIPE, stderr=PIPE)
-			_stdout, _stderr = session.communicate()
+			#session = subprocess.Popen(['nm', binary], stdout=PIPE, stderr=PIPE)
+			#_stdout, _stderr = session.communicate()
+			_stdout = subprocess.check_output(['nm', binary], stderr=PIPE, encoding="utf-8")
 			nm_symbols = _stdout.split('\n')
 			for nm_symbol in nm_symbols:
 				sentry = nm_symbol.split()

--- a/lib/py/het.py
+++ b/lib/py/het.py
@@ -79,7 +79,7 @@ class Converter():
 				if sentry is not None:
 					if len(sentry) >2:
 						binary_symbols[sentry[2]] = sentry[0]
-		return long(binary_symbols[symbol], 16)
+		return int(binary_symbols[symbol], 16)
 
 	def __get_symbol_addr(self, binary, symbol):
 		###find address of the structure
@@ -90,7 +90,7 @@ class Converter():
 			e = ELF(binary)
 			ELF_binaries[binary] = e
 
-		addr=long(e.symbols[symbol])
+		addr=int(e.symbols[symbol])
 		het_log("found address", hex(addr))
 		return addr
 
@@ -116,7 +116,7 @@ class Converter():
 		region_offset=-1
 		for dc in  pgm_img['entries']:
 			if 'vaddr' in dc.keys():
-				base = long(dc['vaddr'], 16)
+				base = int(dc['vaddr'], 16)
 				pnbr = dc['nr_pages']
 				end = base+(pnbr*PAGE_SIZE)
 				het_log("current region", hex(base), hex(end), pnbr)

--- a/lib/py/het.py
+++ b/lib/py/het.py
@@ -5,13 +5,13 @@
 import os
 import json
 import sys
-import pycriu
 import copy
 import shutil
 import tempfile
 import time
 import subprocess
 
+from . import images as pycriu_images
 from os import listdir
 from os.path import isfile, join
 from collections import OrderedDict
@@ -99,8 +99,8 @@ class Converter():
 			return IMG_files[file_path]
 
 		try:
-			pgm_img = pycriu.images.load(open(file_path, 'rb'), pretty=True)
-		except pycriu.images.MagicException as exc:
+			pgm_img = pycriu_images.load(open(file_path, 'rb'), pretty=True)
+		except pycriu_images.MagicException as exc:
 			print("Error reading", file_path)
 			sys.exit(1)
 
@@ -490,7 +490,7 @@ class Converter():
 				het_log("copy of pages file (mem) already done above... we modified the final copy directly")
 			else:
 				het_log("src", dest_img, "dst", dst_file)
-				pycriu.images.dump(dest_img, open(dst_file, "w+"))
+				pycriu_images.dump(dest_img, open(dst_file, "w+"))
 		time_copy = time.time()
 		print (pid, (time_path - time_start), (time_core - time_path), (time_files - time_core), (time_mem - time_files), (time_copy - time_mem))
 		return handled_files

--- a/scripts/crit-setup.py
+++ b/scripts/crit-setup.py
@@ -1,5 +1,11 @@
 from distutils.core import setup
+import os
 
+CUSTOM_PKG_DIR = os.environ["PY_PKG_DIR"]
+DEFAULT_PKG_DIR = "pycriu"
+
+if CUSTOM_PKG_DIR is None or CUSTOM_PKG_DIR == "":
+    CUSTOM_PKG_DIR = DEFAULT_PKG_DIR
 
 setup(name = "crit",
       version = "0.0.1",
@@ -7,8 +13,8 @@ setup(name = "crit",
       author = "CRIU team",
       author_email = "criu@openvz.org",
       url = "https://github.com/xemul/criu",
-      package_dir = {'pycriu': 'lib/py'},
-      packages = ["pycriu", "pycriu.images"],
+      package_dir = {CUSTOM_PKG_DIR: 'lib/py'},
+      packages = [CUSTOM_PKG_DIR, CUSTOM_PKG_DIR + ".images"],
       package_data={'': ['templates/*.tmpl']},
       scripts = ["crit/crit"]
       )

--- a/scripts/crit-setup.py
+++ b/scripts/crit-setup.py
@@ -1,11 +1,11 @@
 from distutils.core import setup
 import os
 
-CUSTOM_PKG_DIR = os.environ["PY_PKG_DIR"]
-DEFAULT_PKG_DIR = "pycriu"
+ENV_KEY = "PY_PKG_DIR"
+CUSTOM_PKG_DIR = "pycriu" # default fallback value
 
-if CUSTOM_PKG_DIR is None or CUSTOM_PKG_DIR == "":
-    CUSTOM_PKG_DIR = DEFAULT_PKG_DIR
+if ENV_KEY in os.environ and os.environ[ENV_KEY].strip() != "":
+    CUSTOM_PKG_DIR = os.environ[ENV_KEY].strip()
 
 setup(name = "crit",
       version = "0.0.1",

--- a/scripts/crit-setup.py
+++ b/scripts/crit-setup.py
@@ -9,7 +9,11 @@ if CUSTOM_PKG_DIR is None or CUSTOM_PKG_DIR == "":
 
 setup(name = "crit",
       version = "0.0.1",
-      description = "CRiu Image Tool",
+      description = "CRiu Image Tool (het and UnASL modifications)",
+      long_description = """CRiu Image Tool based on the criu-het fork
+      which adds a "recode" command for recoding images between ISAs using
+      Popcorn embedded data in the original binaries.
+      The UnASL modifications do not use these embedded data for this recoding.""",
       author = "CRIU team",
       author_email = "criu@openvz.org",
       url = "https://github.com/xemul/criu",


### PR DESCRIPTION
This PR does the following:

- Minor fixes to support Python 3.
- Converts absolute imports of `pycriu` Python library to relative.
- Allows configuring the name of the `pycriu` Python library to allow multiple installations and correct imports in the `crit` commandline tool.
- Fixes build generation of the `crit` commandline tool in order to be always up to date with the last `make` invocation.
- Enhances documentation with the above information.

This addresses https://github.com/systems-nuts/UnASL/issues/165