### PR TITLE
Fix AArch64 build

### DIFF
--- a/criu/arch/aarch64/include/asm/restore.h
+++ b/criu/arch/aarch64/include/asm/restore.h
@@ -15,7 +15,7 @@
 			: "r"(new_sp),				\
 			  "r"(restore_task_exec_start),		\
 			  "r"(task_args)			\
-			: "sp", "x0", "memory")
+			: "x0", "memory")
 
 static inline void core_get_tls(CoreEntry *pcore, tls_t *ptls)
 {

--- a/criu/lsm.c
+++ b/criu/lsm.c
@@ -61,7 +61,7 @@ static int apparmor_get_label(pid_t pid, char **profile_name)
 #ifdef CONFIG_HAS_SELINUX
 static int selinux_get_label(pid_t pid, char **output)
 {
-	security_context_t ctx;
+	char *ctx;
 	char *pos, *last;
 	int i;
 


### PR DESCRIPTION
This PR fixes:

- Build error due to newer GCC versions as documented [here][1].
- Build error due to deprecated SELinux data structure as changed [here][2] and documented [here][3].

Addresses https://github.com/systems-nuts/UnASL/issues/181

[1]: https://github.com/checkpoint-restore/criu/issues/705
[2]: https://github.com/SELinuxProject/selinux/commit/9eb9c9327563014ad6a807814e7975424642d5b9
[3]: https://github.com/SELinuxProject/selinux/commit/7a124ca2758136f49cc38efc26fb1a2d385ecfd9