### PR TITLE
Backport Python 3 fixes for IO encoding and formatting

### DIFF
--- a/lib/py/cli.py
+++ b/lib/py/cli.py
@@ -8,370 +8,474 @@ from shutil import copyfile
 from . import images as pycriu_images
 from .het import Aarch64Converter, X8664Converter
 
-def inf(opts):
-	if opts['in']:
-		return open(opts['in'], 'rb')
-	else:
-		return sys.stdin
 
-def outf(opts):
-	if opts['out']:
-		return open(opts['out'], 'w+')
-	else:
-		return sys.stdout
+def inf(opts):
+    if opts["in"]:
+        return open(opts["in"], "rb")
+    else:
+        if sys.version_info < (3, 0):
+            return sys.stdin
+        if sys.stdin.isatty():
+            # If we are reading from a terminal (not a pipe) we want text input and not binary
+            return sys.stdin
+        return sys.stdin.buffer
+
+
+def outf(opts, decode):
+    # Decode means from protobuf to JSON.
+    # Use text when writing to JSON else use binaray mode
+    if opts["out"]:
+        mode = "wb+"
+        if decode:
+            mode = "w+"
+        return open(opts["out"], mode)
+    else:
+        if sys.version_info < (3, 0):
+            return sys.stdout
+        if decode:
+            return sys.stdout
+        return sys.stdout.buffer
+
 
 def dinf(opts, name):
-	return open(os.path.join(opts['dir'], name))
+    return open(os.path.join(opts["dir"], name), mode="rb")
+
 
 def decode(opts):
-	indent = None
+    indent = None
 
-	try:
-		img = pycriu_images.load(inf(opts), opts['pretty'], opts['nopl'])
-	except pycriu_images.MagicException as exc:
-		print("Unknown magic %#x.\n"\
-				"Maybe you are feeding me an image with "\
-				"raw data(i.e. pages.img)?" % exc.magic, file=sys.stderr)
-		sys.exit(1)
+    try:
+        img = pycriu_images.load(inf(opts), opts["pretty"], opts["nopl"])
+    except pycriu_images.MagicException as exc:
+        print(
+            "Unknown magic %#x.\n"
+            "Maybe you are feeding me an image with "
+            "raw data(i.e. pages.img)?" % exc.magic,
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-	if opts['pretty']:
-		indent = 4
+    if opts["pretty"]:
+        indent = 4
 
-	f = outf(opts)
-	json.dump(img, f, indent=indent)
-	if f == sys.stdout:
-		f.write("\n")
+    f = outf(opts, True)
+    json.dump(img, f, indent=indent)
+    if f == sys.stdout:
+        f.write("\n")
+
 
 def get_default_arg(opts, arg, default=""):
-	if opts[arg]:
-		return opts[arg]
-	return default
+    if opts[arg]:
+        return opts[arg]
+    return default
+
+
 def recode(opts):
-	arch=get_default_arg(opts, "target", "aarch64")
-	directory=get_default_arg(opts, 'directory', ".")
-	outdir=get_default_arg(opts, 'out', "new_image."+str(arch))
-	path_append=get_default_arg(opts, 'append', "")
-	root_dir=get_default_arg(opts, 'root',"")
-	if arch == "aarch64":
-		converter = Aarch64Converter()
-	elif arch == "x86_64" or arch == "x86-64":
-		converter = X8664Converter()
-	converter.recode(arch, directory, outdir, path_append, root_dir)
+    arch = get_default_arg(opts, "target", "aarch64")
+    directory = get_default_arg(opts, "directory", ".")
+    outdir = get_default_arg(opts, "out", "new_image." + str(arch))
+    path_append = get_default_arg(opts, "append", "")
+    root_dir = get_default_arg(opts, "root", "")
+    if arch == "aarch64":
+        converter = Aarch64Converter()
+    elif arch == "x86_64" or arch == "x86-64":
+        converter = X8664Converter()
+    converter.recode(arch, directory, outdir, path_append, root_dir)
+
 
 def encode(opts):
-	img = json.load(inf(opts))
-	pycriu_images.dump(img, outf(opts))
+    img = json.load(inf(opts))
+    pycriu_images.dump(img, outf(opts, False))
+
 
 def info(opts):
-	infs = pycriu_images.info(inf(opts))
-	json.dump(infs, sys.stdout, indent = 4)
-	print()
+    infs = pycriu_images.info(inf(opts))
+    json.dump(infs, sys.stdout, indent=4)
+    print()
+
 
 def get_task_id(p, val):
-	return p[val] if val in p else p['ns_' + val][0]
+    return p[val] if val in p else p["ns_" + val][0]
+
+
 #
 # Explorers
 #
 
-class ps_item:
-	def __init__(self, p, core):
-		self.pid = get_task_id(p, 'pid')
-		self.ppid = p['ppid']
-		self.p = p
-		self.core = core
-		self.kids = []
 
-def show_ps(p, opts, depth = 0):
-	print("%7d%7d%7d   %s%s" % (p.pid, get_task_id(p.p, 'pgid'), get_task_id(p.p, 'sid'),
-			' ' * (4 * depth), p.core['tc']['comm']))
-	for kid in p.kids:
-		show_ps(kid, opts, depth + 1)
+class ps_item:
+    def __init__(self, p, core):
+        self.pid = get_task_id(p, "pid")
+        self.ppid = p["ppid"]
+        self.p = p
+        self.core = core
+        self.kids = []
+
+
+def show_ps(p, opts, depth=0):
+    print(
+        "%7d%7d%7d   %s%s"
+        % (
+            p.pid,
+            get_task_id(p.p, "pgid"),
+            get_task_id(p.p, "sid"),
+            " " * (4 * depth),
+            p.core["tc"]["comm"],
+        )
+    )
+    for kid in p.kids:
+        show_ps(kid, opts, depth + 1)
+
 
 def explore_ps(opts):
-	pss = { }
-	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
-	for p in ps_img['entries']:
-		core = pycriu_images.load(dinf(opts, 'core-%d.img' % get_task_id(p, 'pid')))
-		ps = ps_item(p, core['entries'][0])
-		pss[ps.pid] = ps
+    pss = {}
+    ps_img = pycriu_images.load(dinf(opts, "pstree.img"))
+    for p in ps_img["entries"]:
+        core = pycriu_images.load(
+            dinf(opts, "core-%d.img" % get_task_id(p, "pid"))
+        )
+        ps = ps_item(p, core["entries"][0])
+        pss[ps.pid] = ps
 
-	# Build tree
-	psr = None
-	for pid in pss:
-		p = pss[pid]
-		if p.ppid == 0:
-			psr = p
-			continue
+    # Build tree
+    psr = None
+    for pid in pss:
+        p = pss[pid]
+        if p.ppid == 0:
+            psr = p
+            continue
 
-		pp = pss[p.ppid]
-		pp.kids.append(p)
+        pp = pss[p.ppid]
+        pp.kids.append(p)
 
-	print("%7s%7s%7s   %s" % ('PID', 'PGID', 'SID', 'COMM'))
-	show_ps(psr, opts)
+    print("%7s%7s%7s   %s" % ("PID", "PGID", "SID", "COMM"))
+    show_ps(psr, opts)
+
 
 files_img = None
 
+
 def ftype_find_in_files(opts, ft, fid):
-	global files_img
+    global files_img
 
-	if files_img is None:
-		try:
-			files_img = pycriu.images.load(dinf(opts, "files.img"))['entries']
-		except:
-			files_img = []
+    if files_img is None:
+        try:
+            files_img = pycriu.images.load(dinf(opts, "files.img"))["entries"]
+        except:
+            files_img = []
 
-	if len(files_img) == 0:
-		return None
+    if len(files_img) == 0:
+        return None
 
-	for f in files_img:
-		if f['id'] == fid:
-			return f
+    for f in files_img:
+        if f["id"] == fid:
+            return f
 
-	return None
+    return None
 
 
 def ftype_find_in_image(opts, ft, fid, img):
-	f = ftype_find_in_files(opts, ft, fid)
-	if f:
-		return f[ft['field']]
+    f = ftype_find_in_files(opts, ft, fid)
+    if f:
+        return f[ft["field"]]
 
-	if ft['img'] == None:
-		ft['img'] = pycriu.images.load(dinf(opts, img))['entries']
-	for f in ft['img']:
-		if f['id'] == fid:
-			return f
-	return None
+    if ft["img"] == None:
+        ft["img"] = pycriu.images.load(dinf(opts, img))["entries"]
+    for f in ft["img"]:
+        if f["id"] == fid:
+            return f
+    return None
+
 
 def ftype_reg(opts, ft, fid):
-	rf = ftype_find_in_image(opts, ft, fid, 'reg-files.img')
-	return rf and rf['name'] or 'unknown path'
+    rf = ftype_find_in_image(opts, ft, fid, "reg-files.img")
+    return rf and rf["name"] or "unknown path"
+
 
 def ftype_pipe(opts, ft, fid):
-	p = ftype_find_in_image(opts, ft, fid, 'pipes.img')
-	return p and 'pipe[%d]' % p['pipe_id'] or 'pipe[?]'
+    p = ftype_find_in_image(opts, ft, fid, "pipes.img")
+    return p and "pipe[%d]" % p["pipe_id"] or "pipe[?]"
+
 
 def ftype_unix(opts, ft, fid):
-	ux = ftype_find_in_image(opts, ft, fid, 'unixsk.img')
-	if not ux:
-		return 'unix[?]'
+    ux = ftype_find_in_image(opts, ft, fid, "unixsk.img")
+    if not ux:
+        return "unix[?]"
 
-	n = ux['name'] and ' %s' % ux['name'] or ''
-	return 'unix[%d (%d)%s]' % (ux['ino'], ux['peer'], n)
+    n = ux["name"] and " %s" % ux["name"] or ""
+    return "unix[%d (%d)%s]" % (ux["ino"], ux["peer"], n)
+
 
 file_types = {
-	'REG':		{'get': ftype_reg,	'img': None,	'field': 'reg'},
-	'PIPE':		{'get': ftype_pipe,	'img': None,	'field': 'pipe'},
-	'UNIXSK':	{'get': ftype_unix,	'img': None,	'field': 'usk'},
+    "REG": {"get": ftype_reg, "img": None, "field": "reg"},
+    "PIPE": {"get": ftype_pipe, "img": None, "field": "pipe"},
+    "UNIXSK": {"get": ftype_unix, "img": None, "field": "usk"},
 }
 
-def ftype_gen(opts, ft, fid):
-	return '%s.%d' % (ft['typ'], fid)
 
-files_cache = { }
+def ftype_gen(opts, ft, fid):
+    return "%s.%d" % (ft["typ"], fid)
+
+
+files_cache = {}
+
 
 def get_file_str(opts, fd):
-	key = (fd['type'], fd['id'])
-	f = files_cache.get(key, None)
-	if not f:
-		ft = file_types.get(fd['type'], {'get': ftype_gen, 'typ': fd['type']})
-		f = ft['get'](opts, ft, fd['id'])
-		files_cache[key] = f
+    key = (fd["type"], fd["id"])
+    f = files_cache.get(key, None)
+    if not f:
+        ft = file_types.get(fd["type"], {"get": ftype_gen, "typ": fd["type"]})
+        f = ft["get"](opts, ft, fd["id"])
+        files_cache[key] = f
 
-	return f
+    return f
+
 
 def explore_fds(opts):
-	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
-	for p in ps_img['entries']:
-		pid = get_task_id(p, 'pid')
-		idi = pycriu_images.load(dinf(opts, 'ids-%s.img' % pid))
-		fdt = idi['entries'][0]['files_id']
-		fdi = pycriu_images.load(dinf(opts, 'fdinfo-%d.img' % fdt))
+    ps_img = pycriu_images.load(dinf(opts, "pstree.img"))
+    for p in ps_img["entries"]:
+        pid = get_task_id(p, "pid")
+        idi = pycriu_images.load(dinf(opts, "ids-%s.img" % pid))
+        fdt = idi["entries"][0]["files_id"]
+        fdi = pycriu_images.load(dinf(opts, "fdinfo-%d.img" % fdt))
 
-		print("%d" % pid)
-		for fd in fdi['entries']:
-			print("\t%7d: %s" % (fd['fd'], get_file_str(opts, fd)))
+        print("%d" % pid)
+        for fd in fdi["entries"]:
+            print("\t%7d: %s" % (fd["fd"], get_file_str(opts, fd)))
 
-		fdi = pycriu_images.load(dinf(opts, 'fs-%d.img' % pid))['entries'][0]
-		print("\t%7s: %s" % ('cwd', get_file_str(opts, {'type': 'REG', 'id': fdi['cwd_id']})))
-		print("\t%7s: %s" % ('root', get_file_str(opts, {'type': 'REG', 'id': fdi['root_id']})))
+        fdi = pycriu_images.load(dinf(opts, "fs-%d.img" % pid))["entries"][0]
+        print(
+            "\t%7s: %s"
+            % ("cwd", get_file_str(opts, {"type": "REG", "id": fdi["cwd_id"]}))
+        )
+        print(
+            "\t%7s: %s"
+            % (
+                "root",
+                get_file_str(opts, {"type": "REG", "id": fdi["root_id"]}),
+            )
+        )
 
 
 class vma_id:
-	def __init__(self):
-		self.__ids = {}
-		self.__last = 1
+    def __init__(self):
+        self.__ids = {}
+        self.__last = 1
 
-	def get(self, iid):
-		ret = self.__ids.get(iid, None)
-		if not ret:
-			ret = self.__last
-			self.__last += 1
-			self.__ids[iid] = ret
+    def get(self, iid):
+        ret = self.__ids.get(iid, None)
+        if not ret:
+            ret = self.__last
+            self.__last += 1
+            self.__ids[iid] = ret
 
-		return ret
+        return ret
+
 
 def explore_mems(opts):
-	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
-	vids = vma_id()
-	for p in ps_img['entries']:
-		pid = get_task_id(p, 'pid')
-		mmi = pycriu_images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]
+    ps_img = pycriu_images.load(dinf(opts, "pstree.img"))
+    vids = vma_id()
+    for p in ps_img["entries"]:
+        pid = get_task_id(p, "pid")
+        mmi = pycriu_images.load(dinf(opts, "mm-%d.img" % pid))["entries"][0]
 
-		print("%d" % pid)
-		print("\t%-36s    %s" % ('exe', get_file_str(opts, {'type': 'REG', 'id': mmi['exe_file_id']})))
+        print("%d" % pid)
+        print(
+            "\t%-36s    %s"
+            % (
+                "exe",
+                get_file_str(opts, {"type": "REG", "id": mmi["exe_file_id"]}),
+            )
+        )
 
-		for vma in mmi['vmas']:
-			st = vma['status']
-			if st & (1 << 10):
-				fn = ' ' + 'ips[%lx]' % vids.get(vma['shmid'])
-			elif st & (1 << 8):
-				fn = ' ' + 'shmem[%lx]' % vids.get(vma['shmid'])
-			elif st & (1 << 11):
-				fn = ' ' + 'packet[%lx]' % vids.get(vma['shmid'])
-			elif st & ((1 << 6) | (1 << 7)):
-				fn = ' ' + get_file_str(opts, {'type': 'REG', 'id': vma['shmid']})
-				if vma['pgoff']:
-					fn += ' + %#lx' % vma['pgoff']
-				if st & (1 << 7):
-					fn += ' (s)'
-			elif st & (1 << 1):
-				fn = ' [stack]'
-			elif st & (1 << 2):
-				fn = ' [vsyscall]'
-			elif st & (1 << 3):
-				fn = ' [vdso]'
-			elif vma['flags'] & 0x0100: # growsdown
-				fn = ' [stack?]'
-			else:
-				fn = ''
+        for vma in mmi["vmas"]:
+            st = vma["status"]
+            if st & (1 << 10):
+                fn = " " + "ips[%lx]" % vids.get(vma["shmid"])
+            elif st & (1 << 8):
+                fn = " " + "shmem[%lx]" % vids.get(vma["shmid"])
+            elif st & (1 << 11):
+                fn = " " + "packet[%lx]" % vids.get(vma["shmid"])
+            elif st & ((1 << 6) | (1 << 7)):
+                fn = " " + get_file_str(
+                    opts, {"type": "REG", "id": vma["shmid"]}
+                )
+                if vma["pgoff"]:
+                    fn += " + %#lx" % vma["pgoff"]
+                if st & (1 << 7):
+                    fn += " (s)"
+            elif st & (1 << 1):
+                fn = " [stack]"
+            elif st & (1 << 2):
+                fn = " [vsyscall]"
+            elif st & (1 << 3):
+                fn = " [vdso]"
+            elif vma["flags"] & 0x0100:  # growsdown
+                fn = " [stack?]"
+            else:
+                fn = ""
 
-			if not st & (1 << 0):
-				fn += ' *'
+            if not st & (1 << 0):
+                fn += " *"
 
-			prot = vma['prot'] & 0x1 and 'r' or '-'
-			prot += vma['prot'] & 0x2 and 'w' or '-'
-			prot += vma['prot'] & 0x4 and 'x' or '-'
+            prot = vma["prot"] & 0x1 and "r" or "-"
+            prot += vma["prot"] & 0x2 and "w" or "-"
+            prot += vma["prot"] & 0x4 and "x" or "-"
 
-			astr = '%08lx-%08lx' % (vma['start'], vma['end'])
-			print("\t%-36s%s%s" % (astr, prot, fn))
+            astr = "%08lx-%08lx" % (vma["start"], vma["end"])
+            print("\t%-36s%s%s" % (astr, prot, fn))
 
 
 def explore_rss(opts):
-	ps_img = pycriu_images.load(dinf(opts, 'pstree.img'))
-	for p in ps_img['entries']:
-		pid = get_task_id(p, 'pid')
-		vmas = pycriu_images.load(dinf(opts, 'mm-%d.img' % pid))['entries'][0]['vmas']
-		pms = pycriu_images.load(dinf(opts, 'pagemap-%d.img' % pid))['entries']
+    ps_img = pycriu_images.load(dinf(opts, "pstree.img"))
+    for p in ps_img["entries"]:
+        pid = get_task_id(p, "pid")
+        vmas = pycriu_images.load(dinf(opts, "mm-%d.img" % pid))["entries"][0][
+            "vmas"
+        ]
+        pms = pycriu_images.load(dinf(opts, "pagemap-%d.img" % pid))["entries"]
 
-		print("%d" % pid)
-		vmi = 0
-		pvmi = -1
-		for pm in pms[1:]:
-			pstr = '\t%lx / %-8d' % (pm['vaddr'], pm['nr_pages'])
-			while vmas[vmi]['end'] <= pm['vaddr']:
-				vmi += 1
+        print("%d" % pid)
+        vmi = 0
+        pvmi = -1
+        for pm in pms[1:]:
+            pstr = "\t%lx / %-8d" % (pm["vaddr"], pm["nr_pages"])
+            while vmas[vmi]["end"] <= pm["vaddr"]:
+                vmi += 1
 
-			pme = pm['vaddr'] + (pm['nr_pages'] << 12)
-			vstr = ''
-			while vmas[vmi]['start'] < pme:
-				vma = vmas[vmi]
-				if vmi == pvmi:
-					vstr += ' ~'
-				else:
-					vstr += ' %08lx / %-8d' % (vma['start'], (vma['end'] - vma['start'])>>12)
-					if vma['status'] & ((1 << 6) | (1 << 7)):
-						vstr += ' ' + get_file_str(opts, {'type': 'REG', 'id': vma['shmid']})
-					pvmi = vmi
-				vstr += '\n\t%23s' % ''
-				vmi += 1
+            pme = pm["vaddr"] + (pm["nr_pages"] << 12)
+            vstr = ""
+            while vmas[vmi]["start"] < pme:
+                vma = vmas[vmi]
+                if vmi == pvmi:
+                    vstr += " ~"
+                else:
+                    vstr += " %08lx / %-8d" % (
+                        vma["start"],
+                        (vma["end"] - vma["start"]) >> 12,
+                    )
+                    if vma["status"] & ((1 << 6) | (1 << 7)):
+                        vstr += " " + get_file_str(
+                            opts, {"type": "REG", "id": vma["shmid"]}
+                        )
+                    pvmi = vmi
+                vstr += "\n\t%23s" % ""
+                vmi += 1
 
-			vmi -= 1
+            vmi -= 1
 
-			print('%-24s%s' % (pstr, vstr))
+            print("%-24s%s" % (pstr, vstr))
 
 
+explorers = {
+    "ps": explore_ps,
+    "fds": explore_fds,
+    "mems": explore_mems,
+    "rss": explore_rss,
+}
 
-explorers = { 'ps': explore_ps, 'fds': explore_fds, 'mems': explore_mems, 'rss': explore_rss }
 
 def explore(opts):
-	explorers[opts['what']](opts)
+    explorers[opts["what"]](opts)
+
 
 def main():
-	desc = 'CRiu Image Tool'
-	parser = argparse.ArgumentParser(description=desc,
-			formatter_class=argparse.RawTextHelpFormatter)
+    desc = "CRiu Image Tool"
+    parser = argparse.ArgumentParser(
+        description=desc, formatter_class=argparse.RawTextHelpFormatter
+    )
 
-	subparsers = parser.add_subparsers(help='Use crit CMD --help for command-specific help')
-	if (sys.version_info[0] == 3 and sys.version_info[1] >= 7) or sys.version_info[0] > 3:
-		subparsers.required = True
+    subparsers = parser.add_subparsers(
+        help="Use crit CMD --help for command-specific help"
+    )
+    if (
+        sys.version_info[0] == 3 and sys.version_info[1] >= 7
+    ) or sys.version_info[0] > 3:
+        subparsers.required = True
 
-	# Decode
-	decode_parser = subparsers.add_parser('decode',
-			help = 'convert criu image from binary type to json')
-	decode_parser.add_argument('--pretty',
-			help = 'Multiline with indents and some numerical fields in field-specific format',
-			action = 'store_true')
-	decode_parser.add_argument('-i',
-			    '--in',
-			help = 'criu image in binary format to be decoded (stdin by default)')
-	decode_parser.add_argument('-o',
-			    '--out',
-			help = 'where to put criu image in json format (stdout by default)')
-	decode_parser.set_defaults(func=decode, nopl=False)
+    # Decode
+    decode_parser = subparsers.add_parser(
+        "decode", help="convert criu image from binary type to json"
+    )
+    decode_parser.add_argument(
+        "--pretty",
+        help="Multiline with indents and some numerical fields in field-specific format",
+        action="store_true",
+    )
+    decode_parser.add_argument(
+        "-i",
+        "--in",
+        help="criu image in binary format to be decoded (stdin by default)",
+    )
+    decode_parser.add_argument(
+        "-o",
+        "--out",
+        help="where to put criu image in json format (stdout by default)",
+    )
+    decode_parser.set_defaults(func=decode, nopl=False)
 
-	# Encode
-	encode_parser = subparsers.add_parser('encode',
-			help = 'convert criu image from json type to binary')
-	encode_parser.add_argument('-i',
-			    '--in',
-			help = 'criu image in json format to be encoded (stdin by default)')
-	encode_parser.add_argument('-o',
-			    '--out',
-			help = 'where to put criu image in binary format (stdout by default)')
-	encode_parser.set_defaults(func=encode)
+    # Encode
+    encode_parser = subparsers.add_parser(
+        "encode", help="convert criu image from json type to binary"
+    )
+    encode_parser.add_argument(
+        "-i",
+        "--in",
+        help="criu image in json format to be encoded (stdin by default)",
+    )
+    encode_parser.add_argument(
+        "-o",
+        "--out",
+        help="where to put criu image in binary format (stdout by default)",
+    )
+    encode_parser.set_defaults(func=encode)
 
-	# Info
-	info_parser = subparsers.add_parser('info',
-			help = 'show info about image')
-	info_parser.add_argument("in")
-	info_parser.set_defaults(func=info)
+    # Info
+    info_parser = subparsers.add_parser("info", help="show info about image")
+    info_parser.add_argument("in")
+    info_parser.set_defaults(func=info)
 
-	# Explore
-	x_parser = subparsers.add_parser('x', help = 'explore image dir')
-	x_parser.add_argument('dir')
-	x_parser.add_argument('what', choices = [ 'ps', 'fds', 'mems', 'rss'])
-	x_parser.set_defaults(func=explore)
+    # Explore
+    x_parser = subparsers.add_parser("x", help="explore image dir")
+    x_parser.add_argument("dir")
+    x_parser.add_argument("what", choices=["ps", "fds", "mems", "rss"])
+    x_parser.set_defaults(func=explore)
 
-	# Show
-	show_parser = subparsers.add_parser('show',
-			help = "convert criu image from binary to human-readable json")
-	show_parser.add_argument("in")
-	show_parser.add_argument('--nopl', help = 'do not show entry payload (if exists)', action = 'store_true')
-	show_parser.set_defaults(func=decode, pretty=True, out=None)
+    # Show
+    show_parser = subparsers.add_parser(
+        "show", help="convert criu image from binary to human-readable json"
+    )
+    show_parser.add_argument("in")
+    show_parser.add_argument(
+        "--nopl",
+        help="do not show entry payload (if exists)",
+        action="store_true",
+    )
+    show_parser.set_defaults(func=decode, pretty=True, out=None)
+
+    # recode
+    recode_parser = subparsers.add_parser(
+        "recode",
+        help="convert criu images from architecture A to Architecture B",
+    )
+    recode_parser.add_argument(
+        "-d",
+        "--directory",
+        help="directory containing the images (local by default)",
+    )
+    recode_parser.add_argument(
+        "-t", "--target", help="target architecture (default: aarch64)"
+    )
+    recode_parser.add_argument(
+        "-a", "--append", help='append path to file names (default: "") '
+    )
+    recode_parser.add_argument("-o", "--out", help="path to output dir")
+    recode_parser.add_argument("-r", "--root", help='root dir (default "")')
+    recode_parser.set_defaults(func=recode, nopl=False)
+
+    opts = vars(parser.parse_args())
+    opts["func"](opts)
 
 
-	# recode
-	recode_parser = subparsers.add_parser('recode',
-			help = 'convert criu images from architecture A to Architecture B')
-	recode_parser.add_argument('-d',
-			    '--directory',
-			help = 'directory containing the images (local by default)')
-	recode_parser.add_argument('-t',
-			    '--target',
-			help = 'target architecture (default: aarch64)')
-	recode_parser.add_argument('-a',
-			    '--append',
-			help = 'append path to file names (default: "") ')
-	recode_parser.add_argument('-o',
-			    '--out',
-			help = 'path to output dir')
-	recode_parser.add_argument('-r',
-	        '--root',
-	        help = 'root dir (default "")')
-	recode_parser.set_defaults(func=recode, nopl=False)
-
-	opts = vars(parser.parse_args())
-	opts["func"](opts)
-
-if __name__ == '__main__':
-	main()
+if __name__ == "__main__":
+    main()

--- a/lib/py/images/images.py
+++ b/lib/py/images/images.py
@@ -12,8 +12,8 @@
 # SIZE       ::= "32 bit integer, equals the PAYLOAD length"
 #
 # Images v1.1 NOTE: MAGIC now consist of 2 32 bit integers, first one is
-#	MAGIC_COMMON or MAGIC_SERVICE and the second one is same as MAGIC
-#	in images V1.0. We don't keep "first" magic in json images.
+# 	MAGIC_COMMON or MAGIC_SERVICE and the second one is same as MAGIC
+# 	in images V1.0. We don't keep "first" magic in json images.
 #
 # In order to convert images to human-readable format, we use dict(json).
 # Using json not only allows us to easily read\write images, but also
@@ -23,18 +23,18 @@
 # Using dict(json) format, criu images can be described like:
 #
 # {
-#	'magic' : 'FOO',
-#	'entries' : [
-#		entry,
-#		...
-#	]
+# 	'magic' : 'FOO',
+# 	'entries' : [
+# 		entry,
+# 		...
+# 	]
 # }
 #
 # Entry, in its turn, could be described as:
 #
 # {
-#	pb_msg,
-#	'extra' : extra_msg
+# 	pb_msg,
+# 	'extra' : extra_msg
 # }
 #
 import io
@@ -42,14 +42,15 @@ import base64
 import struct
 import os
 import array
+import sys
 
 from . import magic
 from . import pb
 from . import pb2dict
 
 if "encodebytes" not in dir(base64):
-	base64.encodebytes = base64.encodestring
-	base64.decodebytes = base64.decodestring
+    base64.encodebytes = base64.encodestring
+    base64.decodebytes = base64.decodestring
 
 #
 # Predefined hardcoded constants
@@ -58,232 +59,247 @@ sizeof_u32 = 4
 sizeof_u64 = 8
 
 # A helper for rounding
-def round_up(x,y):
-	return (((x - 1) | (y - 1)) + 1)
+def round_up(x, y):
+    return ((x - 1) | (y - 1)) + 1
+
 
 class MagicException(Exception):
-	def __init__(self, magic):
-		self.magic = magic
+    def __init__(self, magic):
+        self.magic = magic
+
 
 # Generic class to handle loading/dumping criu images entries from/to bin
 # format to/from dict(json).
 class entry_handler:
-	"""
-	Generic class to handle loading/dumping criu images
-	entries from/to bin format to/from dict(json).
-	"""
-	def __init__(self, payload, extra_handler=None):
-		"""
-		Sets payload class and extra handler class.
-		"""
-		self.payload		= payload
-		self.extra_handler	= extra_handler
+    """
+    Generic class to handle loading/dumping criu images
+    entries from/to bin format to/from dict(json).
+    """
 
-	def load(self, f, pretty = False, no_payload = False):
-		"""
-		Convert criu image entries from binary format to dict(json).
-		Takes a file-like object and returnes a list with entries in
-		dict(json) format.
-		"""
-		entries = []
+    def __init__(self, payload, extra_handler=None):
+        """
+        Sets payload class and extra handler class.
+        """
+        self.payload = payload
+        self.extra_handler = extra_handler
 
-		while True:
-			entry = {}
+    def load(self, f, pretty=False, no_payload=False):
+        """
+        Convert criu image entries from binary format to dict(json).
+        Takes a file-like object and returns a list with entries in
+        dict(json) format.
+        """
+        entries = []
 
-			# Read payload
-			pbuff = self.payload()
-			buf = f.read(4)
-			if buf == b'':
-				break
-			size, = struct.unpack('i', buf)
-			pbuff.ParseFromString(f.read(size))
-			entry = pb2dict.pb2dict(pbuff, pretty)
+        while True:
+            entry = {}
 
-			# Read extra
-			if self.extra_handler:
-				if no_payload:
-					def human_readable(num):
-						for unit in ['','K','M','G','T','P','E','Z']:
-							if num < 1024.0:
-								if int(num) == num:
-									return "%d%sB" % (num, unit)
-								else:
-									return "%.1f%sB" % (num, unit)
-							num /= 1024.0
-						return "%.1fYB" % num
+            # Read payload
+            pbuff = self.payload()
+            buf = f.read(4)
+            if buf == b"":
+                break
+            (size,) = struct.unpack("i", buf)
+            pbuff.ParseFromString(f.read(size))
+            entry = pb2dict.pb2dict(pbuff, pretty)
 
-					pl_size = self.extra_handler.skip(f, pbuff)
-					entry['extra'] = '... <%s>' % human_readable(pl_size)
-				else:
-					entry['extra'] = self.extra_handler.load(f, pbuff)
+            # Read extra
+            if self.extra_handler:
+                if no_payload:
 
-			entries.append(entry)
+                    def human_readable(num):
+                        for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
+                            if num < 1024.0:
+                                if int(num) == num:
+                                    return "%d%sB" % (num, unit)
+                                else:
+                                    return "%.1f%sB" % (num, unit)
+                            num /= 1024.0
+                        return "%.1fYB" % num
 
-		return entries
+                    pl_size = self.extra_handler.skip(f, pbuff)
+                    entry["extra"] = "... <%s>" % human_readable(pl_size)
+                else:
+                    entry["extra"] = self.extra_handler.load(f, pbuff)
 
-	def loads(self, s, pretty = False):
-		"""
-		Same as load(), but takes a string as an argument.
-		"""
-		f = io.BytesIO(s)
-		return self.load(f, pretty)
+            entries.append(entry)
 
-	def dump(self, entries, f):
-		"""
-		Convert criu image entries from dict(json) format to binary.
-		Takes a list of entries and a file-like object to write entries
-		in binary format to.
-		"""
-		for entry in entries:
-			extra = entry.pop('extra', None)
+        return entries
 
-			# Write payload
-			pbuff = self.payload()
-			pb2dict.dict2pb(entry, pbuff)
-			pb_str = pbuff.SerializeToString()
-			size = len(pb_str)
-			f.write(struct.pack('i', size))
-			f.write(pb_str)
+    def loads(self, s, pretty=False):
+        """
+        Same as load(), but takes a string as an argument.
+        """
+        f = io.BytesIO(s)
+        return self.load(f, pretty)
 
-			# Write extra
-			if self.extra_handler and extra:
-				self.extra_handler.dump(extra, f, pbuff)
+    def dump(self, entries, f):
+        """
+        Convert criu image entries from dict(json) format to binary.
+        Takes a list of entries and a file-like object to write entries
+        in binary format to.
+        """
+        for entry in entries:
+            extra = entry.pop("extra", None)
 
-	def dumps(self, entries):
-		"""
-		Same as dump(), but doesn't take file-like object and just
-		returns a string.
-		"""
-		f = io.BytesIO('')
-		self.dump(entries, f)
-		return f.read()
+            # Write payload
+            pbuff = self.payload()
+            pb2dict.dict2pb(entry, pbuff)
+            pb_str = pbuff.SerializeToString()
+            size = len(pb_str)
+            f.write(struct.pack("i", size))
+            f.write(pb_str)
 
-	def count(self, f):
-		"""
-		Counts the number of top-level object in the image file
-		"""
-		entries = 0
+            # Write extra
+            if self.extra_handler and extra:
+                self.extra_handler.dump(extra, f, pbuff)
 
-		while True:
-			buf = f.read(4)
-			if buf == '':
-				break
-			size, = struct.unpack('i', buf)
-			f.seek(size, 1)
-			entries += 1
+    def dumps(self, entries):
+        """
+        Same as dump(), but doesn't take file-like object and just
+        returns a string.
+        """
+        f = io.BytesIO("")
+        self.dump(entries, f)
+        return f.read()
 
-		return entries
+    def count(self, f):
+        """
+        Counts the number of top-level object in the image file
+        """
+        entries = 0
+
+        while True:
+            buf = f.read(4)
+            if buf == "":
+                break
+            (size,) = struct.unpack("i", buf)
+            f.seek(size, 1)
+            entries += 1
+
+        return entries
+
 
 # Special handler for pagemap.img
 class pagemap_handler:
-	"""
-	Special entry handler for pagemap.img, which is unique in a way
-	that it has a header of pagemap_head type followed by entries
-	of pagemap_entry type.
-	"""
-	def load(self, f, pretty = False, no_payload = False):
-		entries = []
+    """
+    Special entry handler for pagemap.img, which is unique in a way
+    that it has a header of pagemap_head type followed by entries
+    of pagemap_entry type.
+    """
 
-		pbuff = pb.pagemap_head()
-		while True:
-			buf = f.read(4)
-			if buf == b'':
-				break
-			size, = struct.unpack('i', buf)
-			pbuff.ParseFromString(f.read(size))
-			entries.append(pb2dict.pb2dict(pbuff, pretty))
+    def load(self, f, pretty=False, no_payload=False):
+        entries = []
 
-			pbuff = pb.pagemap_entry()
+        pbuff = pb.pagemap_head()
+        while True:
+            buf = f.read(4)
+            if buf == b"":
+                break
+            (size,) = struct.unpack("i", buf)
+            pbuff.ParseFromString(f.read(size))
+            entries.append(pb2dict.pb2dict(pbuff, pretty))
 
-		return entries
+            pbuff = pb.pagemap_entry()
 
-	def loads(self, s, pretty = False):
-		f = io.BytesIO(s)
-		return self.load(f, pretty)
+        return entries
 
-	def dump(self, entries, f):
-		pbuff = pb.pagemap_head()
-		for item in entries:
-			pb2dict.dict2pb(item, pbuff)
-			pb_str = pbuff.SerializeToString()
-			size = len(pb_str)
-			f.write(struct.pack('i', size))
-			f.write(pb_str)
+    def loads(self, s, pretty=False):
+        f = io.BytesIO(s)
+        return self.load(f, pretty)
 
-			pbuff = pb.pagemap_entry()
+    def dump(self, entries, f):
+        pbuff = pb.pagemap_head()
+        for item in entries:
+            pb2dict.dict2pb(item, pbuff)
+            pb_str = pbuff.SerializeToString()
+            size = len(pb_str)
+            f.write(struct.pack("i", size))
+            f.write(pb_str)
 
-	def dumps(self, entries):
-		f = io.BytesIO('')
-		self.dump(entries, f)
-		return f.read()
+            pbuff = pb.pagemap_entry()
 
-	def count(self, f):
-		return entry_handler(None).count(f) - 1
+    def dumps(self, entries):
+        f = io.BytesIO("")
+        self.dump(entries, f)
+        return f.read()
+
+    def count(self, f):
+        return entry_handler(None).count(f) - 1
+
 
 # Special handler for ghost-file.img
 class ghost_file_handler:
-	def load(self, f, pretty = False, no_payload = False):
-		entries = []
+    def load(self, f, pretty=False, no_payload=False):
+        entries = []
 
-		gf = pb.ghost_file_entry()
-		buf = f.read(4)
-		size, = struct.unpack('i', buf)
-		gf.ParseFromString(f.read(size))
-		g_entry = pb2dict.pb2dict(gf, pretty)
+        gf = pb.ghost_file_entry()
+        buf = f.read(4)
+        (size,) = struct.unpack("i", buf)
+        gf.ParseFromString(f.read(size))
+        g_entry = pb2dict.pb2dict(gf, pretty)
 
-		if gf.chunks:
-			entries.append(g_entry)
-			while True:
-				gc = pb.ghost_chunk_entry()
-				buf = f.read(4)
-				if buf == '':
-					break
-				size, = struct.unpack('i', buf)
-				gc.ParseFromString(f.read(size))
-				entry = pb2dict.pb2dict(gc, pretty)
-				if no_payload:
-					f.seek(gc.len, os.SEEK_CUR)
-				else:
-					entry['extra'] = base64.encodebytes(f.read(gc.len))
-				entries.append(entry)
-		else:
-			if no_payload:
-				f.seek(0, os.SEEK_END)
-			else:
-				g_entry['extra'] = base64.encodebytes(f.read())
-			entries.append(g_entry)
+        if gf.chunks:
+            entries.append(g_entry)
+            while True:
+                gc = pb.ghost_chunk_entry()
+                buf = f.read(4)
+                if len(buf) == 0:
+                    break
+                (size,) = struct.unpack("i", buf)
+                gc.ParseFromString(f.read(size))
+                entry = pb2dict.pb2dict(gc, pretty)
+                if no_payload:
+                    f.seek(gc.len, os.SEEK_CUR)
+                else:
+                    entry["extra"] = base64.encodebytes(f.read(gc.len)).decode(
+                        "utf-8"
+                    )
+                entries.append(entry)
+        else:
+            if no_payload:
+                f.seek(0, os.SEEK_END)
+            else:
+                g_entry["extra"] = base64.encodebytes(f.read()).decode("utf-8")
+            entries.append(g_entry)
 
-		return entries
+        return entries
 
-	def loads(self, s, pretty = False):
-		f = io.BytesIO(s)
-		return self.load(f, pretty)
+    def loads(self, s, pretty=False):
+        f = io.BytesIO(s)
+        return self.load(f, pretty)
 
-	def dump(self, entries, f):
-		pbuff = pb.ghost_file_entry()
-		item = entries.pop(0)
-		pb2dict.dict2pb(item, pbuff)
-		pb_str = pbuff.SerializeToString()
-		size = len(pb_str)
-		f.write(struct.pack('i', size))
-		f.write(pb_str)
+    def dump(self, entries, f):
+        pbuff = pb.ghost_file_entry()
+        item = entries.pop(0)
+        pb2dict.dict2pb(item, pbuff)
+        pb_str = pbuff.SerializeToString()
+        size = len(pb_str)
+        f.write(struct.pack("i", size))
+        f.write(pb_str)
 
-		if pbuff.chunks:
-			for item in entries:
-				pbuff = pb.ghost_chunk_entry()
-				pb2dict.dict2pb(item, pbuff)
-				pb_str = pbuff.SerializeToString()
-				size = len(pb_str)
-				f.write(struct.pack('i', size))
-				f.write(pb_str)
-				f.write(base64.decodebytes(item['extra']))
-		else:
-			f.write(base64.decodebytes(item['extra']))
+        if pbuff.chunks:
+            for item in entries:
+                pbuff = pb.ghost_chunk_entry()
+                pb2dict.dict2pb(item, pbuff)
+                pb_str = pbuff.SerializeToString()
+                size = len(pb_str)
+                f.write(struct.pack("i", size))
+                f.write(pb_str)
+                if sys.version_info > (3, 0):
+                    f.write(base64.decodebytes(str.encode(item["extra"])))
+                else:
+                    f.write(base64.decodebytes(item["extra"]))
+        else:
+            if sys.version_info > (3, 0):
+                f.write(base64.decodebytes(str.encode(item["extra"])))
+            else:
+                f.write(base64.decodebytes(item["extra"]))
 
-	def dumps(self, entries):
-		f = io.BytesIO('')
-		self.dump(entries, f)
-		return f.read()
+    def dumps(self, entries):
+        f = io.BytesIO("")
+        self.dump(entries, f)
+        return f.read()
 
 
 # In following extra handlers we use base64 encoding
@@ -293,304 +309,333 @@ class ghost_file_handler:
 # do not store big amounts of binary data. They
 # are negligible comparing to pages size.
 class pipes_data_extra_handler:
-	def load(self, f, pload):
-		size = pload.bytes
-		data = f.read(size)
-		return base64.encodebytes(data)
+    def load(self, f, pload):
+        size = pload.bytes
+        data = f.read(size)
+        return base64.encodebytes(data).decode("utf-8")
 
-	def dump(self, extra, f, pload):
-		data = base64.decodebytes(extra)
-		f.write(data)
+    def dump(self, extra, f, pload):
+        if sys.version_info > (3, 0):
+            data = base64.decodebytes(str.encode(extra))
+        else:
+            data = base64.decodebytes(extra)
+        f.write(data)
 
-	def skip(self, f, pload):
-		f.seek(pload.bytes, os.SEEK_CUR)
-		return pload.bytes
+    def skip(self, f, pload):
+        f.seek(pload.bytes, os.SEEK_CUR)
+        return pload.bytes
+
 
 class sk_queues_extra_handler:
-	def load(self, f, pload):
-		size = pload.length
-		data = f.read(size)
-		return base64.encodebytes(data)
+    def load(self, f, pload):
+        size = pload.length
+        data = f.read(size)
+        return base64.encodebytes(data).decode("utf-8")
 
-	def dump(self, extra, f, _unused):
-		data = base64.decodebytes(extra)
-		f.write(data)
+    def dump(self, extra, f, _unused):
+        if sys.version_info > (3, 0):
+            data = base64.decodebytes(str.encode(extra))
+        else:
+            data = base64.decodebytes(extra)
+        f.write(data)
 
-	def skip(self, f, pload):
-		f.seek(pload.length, os.SEEK_CUR)
-		return pload.length
+    def skip(self, f, pload):
+        f.seek(pload.length, os.SEEK_CUR)
+        return pload.length
 
 
 class tcp_stream_extra_handler:
-	def load(self, f, pbuff):
-		d = {}
+    def load(self, f, pbuff):
+        d = {}
 
-		inq	= f.read(pbuff.inq_len)
-		outq	= f.read(pbuff.outq_len)
+        inq = f.read(pbuff.inq_len)
+        outq = f.read(pbuff.outq_len)
 
-		d['inq']	= base64.encodebytes(inq)
-		d['outq']	= base64.encodebytes(outq)
+        d["inq"] = base64.encodebytes(inq).decode("utf-8")
+        d["outq"] = base64.encodebytes(outq).decode("utf-8")
 
-		return d
+        return d
 
-	def dump(self, extra, f, _unused):
-		inq	= base64.decodebytes(extra['inq'])
-		outq	= base64.decodebytes(extra['outq'])
+    def dump(self, extra, f, _unused):
+        if sys.version_info > (3, 0):
+            inq = base64.decodebytes(str.encode(extra["inq"]))
+            outq = base64.decodebytes(str.encode(extra["outq"]))
+        else:
+            inq = base64.decodebytes(extra["inq"])
+            outq = base64.decodebytes(extra["outq"])
 
-		f.write(inq)
-		f.write(outq)
+        f.write(inq)
+        f.write(outq)
 
-	def skip(self, f, pbuff):
-		f.seek(0, os.SEEK_END)
-		return pbuff.inq_len + pbuff.outq_len
+    def skip(self, f, pbuff):
+        f.seek(0, os.SEEK_END)
+        return pbuff.inq_len + pbuff.outq_len
+
 
 class ipc_sem_set_handler:
-	def load(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = sizeof_u16 * entry['nsems']
-		rounded = round_up(size, sizeof_u64)
-		s = array.array('H')
-		if s.itemsize != sizeof_u16:
-			raise Exception("Array size mismatch")
-		s.fromstring(f.read(size))
-		f.seek(rounded - size, 1)
-		return s.tolist()
+    def load(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = sizeof_u16 * entry["nsems"]
+        rounded = round_up(size, sizeof_u64)
+        s = array.array("H")
+        if s.itemsize != sizeof_u16:
+            raise Exception("Array size mismatch")
+        s.frombytes(f.read(size))
+        f.seek(rounded - size, 1)
+        return s.tolist()
 
-	def dump(self, extra, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = sizeof_u16 * entry['nsems']
-		rounded = round_up(size, sizeof_u64)
-		s = array.array('H')
-		if s.itemsize != sizeof_u16:
-			raise Exception("Array size mismatch")
-		s.fromlist(extra)
-		if len(s) != entry['nsems']:
-			raise Exception("Number of semaphores mismatch")
-		f.write(s.tostring())
-		f.write('\0' * (rounded - size))
+    def dump(self, extra, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = sizeof_u16 * entry["nsems"]
+        rounded = round_up(size, sizeof_u64)
+        s = array.array("H")
+        if s.itemsize != sizeof_u16:
+            raise Exception("Array size mismatch")
+        s.fromlist(extra)
+        if len(s) != entry["nsems"]:
+            raise Exception("Number of semaphores mismatch")
+        f.write(s.tobytes())
+        f.write(b"\0" * (rounded - size))
 
-	def skip(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = sizeof_u16 * entry['nsems']
-		f.seek(round_up(size, sizeof_u64), os.SEEK_CUR)
-		return size
+    def skip(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = sizeof_u16 * entry["nsems"]
+        f.seek(round_up(size, sizeof_u64), os.SEEK_CUR)
+        return size
+
 
 class ipc_msg_queue_handler:
-	def load(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		messages = []
-		for x in range (0, entry['qnum']):
-			buf = f.read(4)
-			if buf == '':
-				break
-			size, = struct.unpack('i', buf)
-			msg = pb.ipc_msg()
-			msg.ParseFromString(f.read(size))
-			rounded = round_up(msg.msize, sizeof_u64)
-			data = f.read(msg.msize)
-			f.seek(rounded - msg.msize, 1)
-			messages.append(pb2dict.pb2dict(msg))
-			messages.append(base64.encodebytes(data))
-		return messages
+    def load(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        messages = []
+        for x in range(0, entry["qnum"]):
+            buf = f.read(4)
+            if buf == "":
+                break
+            (size,) = struct.unpack("i", buf)
+            msg = pb.ipc_msg()
+            msg.ParseFromString(f.read(size))
+            rounded = round_up(msg.msize, sizeof_u64)
+            data = f.read(msg.msize)
+            f.seek(rounded - msg.msize, 1)
+            messages.append(pb2dict.pb2dict(msg))
+            messages.append(base64.encodebytes(data).decode("utf-8"))
+        return messages
 
-	def dump(self, extra, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		for i in range (0, len(extra), 2):
-			msg = pb.ipc_msg()
-			pb2dict.dict2pb(extra[i], msg)
-			msg_str = msg.SerializeToString()
-			size = len(msg_str)
-			f.write(struct.pack('i', size))
-			f.write(msg_str)
-			rounded = round_up(msg.msize, sizeof_u64)
-			data = base64.decodebytes(extra[i + 1])
-			f.write(data[:msg.msize])
-			f.write('\0' * (rounded - msg.msize))
+    def dump(self, extra, f, pbuff):
+        for i in range(0, len(extra), 2):
+            msg = pb.ipc_msg()
+            pb2dict.dict2pb(extra[i], msg)
+            msg_str = msg.SerializeToString()
+            size = len(msg_str)
+            f.write(struct.pack("i", size))
+            f.write(msg_str)
+            rounded = round_up(msg.msize, sizeof_u64)
+            if sys.version_info > (3, 0):
+                data = base64.decodebytes(str.encode(extra[i + 1]))
+            else:
+                data = base64.decodebytes(extra[i + 1])
+            f.write(data[: msg.msize])
+            f.write(b"\0" * (rounded - msg.msize))
 
-	def skip(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		pl_len = 0
-		for x in range (0, entry['qnum']):
-			buf = f.read(4)
-			if buf == '':
-				break
-			size, = struct.unpack('i', buf)
-			msg = pb.ipc_msg()
-			msg.ParseFromString(f.read(size))
-			rounded = round_up(msg.msize, sizeof_u64)
-			f.seek(rounded, os.SEEK_CUR)
-			pl_len += size + msg.msize
+    def skip(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        pl_len = 0
+        for x in range(0, entry["qnum"]):
+            buf = f.read(4)
+            if buf == "":
+                break
+            (size,) = struct.unpack("i", buf)
+            msg = pb.ipc_msg()
+            msg.ParseFromString(f.read(size))
+            rounded = round_up(msg.msize, sizeof_u64)
+            f.seek(rounded, os.SEEK_CUR)
+            pl_len += size + msg.msize
 
-		return pl_len
+        return pl_len
+
 
 class ipc_shm_handler:
-	def load(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = entry['size']
-		data = f.read(size)
-		rounded = round_up(size, sizeof_u32)
-		f.seek(rounded - size, 1)
-		return base64.encodebytes(data)
+    def load(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = entry["size"]
+        data = f.read(size)
+        rounded = round_up(size, sizeof_u32)
+        f.seek(rounded - size, 1)
+        return base64.encodebytes(data).decode("utf-8")
 
-	def dump(self, extra, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = entry['size']
-		data = base64.decodebytes(extra)
-		rounded = round_up(size, sizeof_u32)
-		f.write(data[:size])
-		f.write('\0' * (rounded - size))
+    def dump(self, extra, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = entry["size"]
+        data = base64.decodebytes(extra)
+        rounded = round_up(size, sizeof_u32)
+        f.write(data[:size])
+        f.write(b"\0" * (rounded - size))
 
-	def skip(self, f, pbuff):
-		entry = pb2dict.pb2dict(pbuff)
-		size = entry['size']
-		rounded = round_up(size, sizeof_u32)
-		f.seek(rounded, os.SEEK_CUR)
-		return size
+    def skip(self, f, pbuff):
+        entry = pb2dict.pb2dict(pbuff)
+        size = entry["size"]
+        rounded = round_up(size, sizeof_u32)
+        f.seek(rounded, os.SEEK_CUR)
+        return size
 
 
 handlers = {
-	'INVENTORY'		: entry_handler(pb.inventory_entry),
-	'CORE'			: entry_handler(pb.core_entry),
-	'IDS'			: entry_handler(pb.task_kobj_ids_entry),
-	'CREDS'			: entry_handler(pb.creds_entry),
-	'UTSNS'			: entry_handler(pb.utsns_entry),
-	'IPC_VAR'		: entry_handler(pb.ipc_var_entry),
-	'FS'			: entry_handler(pb.fs_entry),
-	'GHOST_FILE'		: ghost_file_handler(),
-	'MM'			: entry_handler(pb.mm_entry),
-	'CGROUP'		: entry_handler(pb.cgroup_entry),
-	'TCP_STREAM'		: entry_handler(pb.tcp_stream_entry, tcp_stream_extra_handler()),
-	'STATS'			: entry_handler(pb.stats_entry),
-	'PAGEMAP'		: pagemap_handler(), # Special one
-	'PSTREE'		: entry_handler(pb.pstree_entry),
-	'REG_FILES'		: entry_handler(pb.reg_file_entry),
-	'NS_FILES'		: entry_handler(pb.ns_file_entry),
-	'EVENTFD_FILE'		: entry_handler(pb.eventfd_file_entry),
-	'EVENTPOLL_FILE'	: entry_handler(pb.eventpoll_file_entry),
-	'EVENTPOLL_TFD'		: entry_handler(pb.eventpoll_tfd_entry),
-	'SIGNALFD'		: entry_handler(pb.signalfd_entry),
-	'TIMERFD'		: entry_handler(pb.timerfd_entry),
-	'INOTIFY_FILE'		: entry_handler(pb.inotify_file_entry),
-	'INOTIFY_WD'		: entry_handler(pb.inotify_wd_entry),
-	'FANOTIFY_FILE'		: entry_handler(pb.fanotify_file_entry),
-	'FANOTIFY_MARK'		: entry_handler(pb.fanotify_mark_entry),
-	'VMAS'			: entry_handler(pb.vma_entry),
-	'PIPES'			: entry_handler(pb.pipe_entry),
-	'FIFO'			: entry_handler(pb.fifo_entry),
-	'SIGACT'		: entry_handler(pb.sa_entry),
-	'NETLINK_SK'		: entry_handler(pb.netlink_sk_entry),
-	'REMAP_FPATH'		: entry_handler(pb.remap_file_path_entry),
-	'MNTS'			: entry_handler(pb.mnt_entry),
-	'TTY_FILES'		: entry_handler(pb.tty_file_entry),
-	'TTY_INFO'		: entry_handler(pb.tty_info_entry),
-	'TTY_DATA'		: entry_handler(pb.tty_data_entry),
-	'RLIMIT'		: entry_handler(pb.rlimit_entry),
-	'TUNFILE'		: entry_handler(pb.tunfile_entry),
-	'EXT_FILES'		: entry_handler(pb.ext_file_entry),
-	'IRMAP_CACHE'		: entry_handler(pb.irmap_cache_entry),
-	'FILE_LOCKS'		: entry_handler(pb.file_lock_entry),
-	'FDINFO'		: entry_handler(pb.fdinfo_entry),
-	'UNIXSK'		: entry_handler(pb.unix_sk_entry),
-	'INETSK'		: entry_handler(pb.inet_sk_entry),
-	'PACKETSK'		: entry_handler(pb.packet_sock_entry),
-	'ITIMERS'		: entry_handler(pb.itimer_entry),
-	'POSIX_TIMERS'		: entry_handler(pb.posix_timer_entry),
-	'NETDEV'		: entry_handler(pb.net_device_entry),
-	'PIPES_DATA'		: entry_handler(pb.pipe_data_entry, pipes_data_extra_handler()),
-	'FIFO_DATA'		: entry_handler(pb.pipe_data_entry, pipes_data_extra_handler()),
-	'SK_QUEUES'		: entry_handler(pb.sk_packet_entry, sk_queues_extra_handler()),
-	'IPCNS_SHM'		: entry_handler(pb.ipc_shm_entry, ipc_shm_handler()),
-	'IPCNS_SEM'		: entry_handler(pb.ipc_sem_entry, ipc_sem_set_handler()),
-	'IPCNS_MSG'		: entry_handler(pb.ipc_msg_entry, ipc_msg_queue_handler()),
-	'NETNS'			: entry_handler(pb.netns_entry),
-	'USERNS'		: entry_handler(pb.userns_entry),
-	'SECCOMP'		: entry_handler(pb.seccomp_entry),
-	'AUTOFS'		: entry_handler(pb.autofs_entry),
-	'FILES'                 : entry_handler(pb.file_entry),
-	'CPUINFO'		: entry_handler(pb.cpuinfo_entry),
-	}
+    "INVENTORY": entry_handler(pb.inventory_entry),
+    "CORE": entry_handler(pb.core_entry),
+    "IDS": entry_handler(pb.task_kobj_ids_entry),
+    "CREDS": entry_handler(pb.creds_entry),
+    "UTSNS": entry_handler(pb.utsns_entry),
+    "IPC_VAR": entry_handler(pb.ipc_var_entry),
+    "FS": entry_handler(pb.fs_entry),
+    "GHOST_FILE": ghost_file_handler(),
+    "MM": entry_handler(pb.mm_entry),
+    "CGROUP": entry_handler(pb.cgroup_entry),
+    "TCP_STREAM": entry_handler(
+        pb.tcp_stream_entry, tcp_stream_extra_handler()
+    ),
+    "STATS": entry_handler(pb.stats_entry),
+    "PAGEMAP": pagemap_handler(),  # Special one
+    "PSTREE": entry_handler(pb.pstree_entry),
+    "REG_FILES": entry_handler(pb.reg_file_entry),
+    "NS_FILES": entry_handler(pb.ns_file_entry),
+    "EVENTFD_FILE": entry_handler(pb.eventfd_file_entry),
+    "EVENTPOLL_FILE": entry_handler(pb.eventpoll_file_entry),
+    "EVENTPOLL_TFD": entry_handler(pb.eventpoll_tfd_entry),
+    "SIGNALFD": entry_handler(pb.signalfd_entry),
+    "TIMERFD": entry_handler(pb.timerfd_entry),
+    "INOTIFY_FILE": entry_handler(pb.inotify_file_entry),
+    "INOTIFY_WD": entry_handler(pb.inotify_wd_entry),
+    "FANOTIFY_FILE": entry_handler(pb.fanotify_file_entry),
+    "FANOTIFY_MARK": entry_handler(pb.fanotify_mark_entry),
+    "VMAS": entry_handler(pb.vma_entry),
+    "PIPES": entry_handler(pb.pipe_entry),
+    "FIFO": entry_handler(pb.fifo_entry),
+    "SIGACT": entry_handler(pb.sa_entry),
+    "NETLINK_SK": entry_handler(pb.netlink_sk_entry),
+    "REMAP_FPATH": entry_handler(pb.remap_file_path_entry),
+    "MNTS": entry_handler(pb.mnt_entry),
+    "TTY_FILES": entry_handler(pb.tty_file_entry),
+    "TTY_INFO": entry_handler(pb.tty_info_entry),
+    "TTY_DATA": entry_handler(pb.tty_data_entry),
+    "RLIMIT": entry_handler(pb.rlimit_entry),
+    "TUNFILE": entry_handler(pb.tunfile_entry),
+    "EXT_FILES": entry_handler(pb.ext_file_entry),
+    "IRMAP_CACHE": entry_handler(pb.irmap_cache_entry),
+    "FILE_LOCKS": entry_handler(pb.file_lock_entry),
+    "FDINFO": entry_handler(pb.fdinfo_entry),
+    "UNIXSK": entry_handler(pb.unix_sk_entry),
+    "INETSK": entry_handler(pb.inet_sk_entry),
+    "PACKETSK": entry_handler(pb.packet_sock_entry),
+    "ITIMERS": entry_handler(pb.itimer_entry),
+    "POSIX_TIMERS": entry_handler(pb.posix_timer_entry),
+    "NETDEV": entry_handler(pb.net_device_entry),
+    "PIPES_DATA": entry_handler(
+        pb.pipe_data_entry, pipes_data_extra_handler()
+    ),
+    "FIFO_DATA": entry_handler(pb.pipe_data_entry, pipes_data_extra_handler()),
+    "SK_QUEUES": entry_handler(pb.sk_packet_entry, sk_queues_extra_handler()),
+    "IPCNS_SHM": entry_handler(pb.ipc_shm_entry, ipc_shm_handler()),
+    "IPCNS_SEM": entry_handler(pb.ipc_sem_entry, ipc_sem_set_handler()),
+    "IPCNS_MSG": entry_handler(pb.ipc_msg_entry, ipc_msg_queue_handler()),
+    "NETNS": entry_handler(pb.netns_entry),
+    "USERNS": entry_handler(pb.userns_entry),
+    "SECCOMP": entry_handler(pb.seccomp_entry),
+    "AUTOFS": entry_handler(pb.autofs_entry),
+    "FILES": entry_handler(pb.file_entry),
+    "CPUINFO": entry_handler(pb.cpuinfo_entry),
+}
+
 
 def __rhandler(f):
-	# Images v1.1 NOTE: First read "first" magic.
-	img_magic, = struct.unpack('i', f.read(4))
-	if img_magic in (magic.by_name['IMG_COMMON'], magic.by_name['IMG_SERVICE']):
-		img_magic, = struct.unpack('i', f.read(4))
+    # Images v1.1 NOTE: First read "first" magic.
+    (img_magic,) = struct.unpack("i", f.read(4))
+    if img_magic in (
+        magic.by_name["IMG_COMMON"],
+        magic.by_name["IMG_SERVICE"],
+    ):
+        (img_magic,) = struct.unpack("i", f.read(4))
 
-	try:
-		m = magic.by_val[img_magic]
-	except:
-		raise MagicException(img_magic)
+    try:
+        m = magic.by_val[img_magic]
+    except:
+        raise MagicException(img_magic)
 
-	try:
-		handler = handlers[m]
-	except:
-		raise Exception("No handler found for image with magic " + m)
+    try:
+        handler = handlers[m]
+    except:
+        raise Exception("No handler found for image with magic " + m)
 
-	return m, handler
+    return m, handler
 
-def load(f, pretty = False, no_payload = False):
-	"""
-	Convert criu image from binary format to dict(json).
-	Takes a file-like object to read criu image from.
-	Returns criu image in dict(json) format.
-	"""
-	image = {}
 
-	m, handler = __rhandler(f)
+def load(f, pretty=False, no_payload=False):
+    """
+    Convert criu image from binary format to dict(json).
+    Takes a file-like object to read criu image from.
+    Returns criu image in dict(json) format.
+    """
+    image = {}
 
-	image['magic'] = m
-	image['entries'] = handler.load(f, pretty, no_payload)
+    m, handler = __rhandler(f)
 
-	return image
+    image["magic"] = m
+    image["entries"] = handler.load(f, pretty, no_payload)
+
+    return image
+
 
 def info(f):
-	res = {}
+    res = {}
 
-	m, handler = __rhandler(f)
+    m, handler = __rhandler(f)
 
-	res['magic'] = m
-	res['count'] = handler.count(f)
+    res["magic"] = m
+    res["count"] = handler.count(f)
 
-	return res
+    return res
 
-def loads(s, pretty = False):
-	"""
-	Same as load(), but takes a string.
-	"""
-	f = io.BytesIO(s)
-	return load(f, pretty)
+
+def loads(s, pretty=False):
+    """
+    Same as load(), but takes a string.
+    """
+    f = io.BytesIO(s)
+    return load(f, pretty)
+
 
 def dump(img, f):
-	"""
-	Convert criu image from dict(json) format to binary.
-	Takes an image in dict(json) format and file-like
-	object to write to.
-	"""
-	m = img['magic']
-	magic_val = magic.by_name[img['magic']]
+    """
+    Convert criu image from dict(json) format to binary.
+    Takes an image in dict(json) format and file-like
+    object to write to.
+    """
+    m = img["magic"]
+    magic_val = magic.by_name[img["magic"]]
 
-	# Images v1.1 NOTE: use "second" magic to identify what "first"
-	# should be written.
-	if m != 'INVENTORY':
-		if m in ('STATS', 'IRMAP_CACHE'):
-			f.write(struct.pack('i', magic.by_name['IMG_SERVICE']))
-		else:
-			f.write(struct.pack('i', magic.by_name['IMG_COMMON']))
+    # Images v1.1 NOTE: use "second" magic to identify what "first"
+    # should be written.
+    if m != "INVENTORY":
+        if m in ("STATS", "IRMAP_CACHE"):
+            f.write(struct.pack("i", magic.by_name["IMG_SERVICE"]))
+        else:
+            f.write(struct.pack("i", magic.by_name["IMG_COMMON"]))
 
-	f.write(struct.pack('i', magic_val))
+    f.write(struct.pack("i", magic_val))
 
-	try:
-		handler = handlers[m]
-	except:
-		raise Exception("No handler found for image with such magic")
+    try:
+        handler = handlers[m]
+    except:
+        raise Exception("No handler found for image with such magic")
 
-	handler.dump(img['entries'], f)
+    handler.dump(img["entries"], f)
+
 
 def dumps(img):
-	"""
-	Same as dump(), but takes only an image and returns
-	a string.
-	"""
-	f = io.BytesIO(b'')
-	dump(img, f)
-	return f.getvalue()
+    """
+    Same as dump(), but takes only an image and returns
+    a string.
+    """
+    f = io.BytesIO(b"")
+    dump(img, f)
+    return f.getvalue()


### PR DESCRIPTION
This PR:

- Backports changes for file I/O encoding for Python 3 while maintaining Python 2 compatibility.
- Reformats the changed files based on the `pyproject.toml` config and `black` formatter.